### PR TITLE
Add utility class tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev:legacy": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --experimental-strip-types --test"
   },
   "dependencies": {
     "@gsap/react": "^2.1.2",

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,11 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { cn } from './utils.ts'
+
+test('merges multiple class strings', () => {
+  assert.equal(cn('px-2', 'px-4', 'text-sm'), 'px-4 text-sm')
+})
+
+test('handles conditional classes', () => {
+  assert.equal(cn('foo', { bar: true, baz: false }), 'foo bar')
+})


### PR DESCRIPTION
## Summary
- add node:test script for running tests
- cover cn utility with merging and conditional class cases

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6899e0a763f08325b83565168d0db7bf